### PR TITLE
static function ArcanistDifferentialRevisionRef::newFromDictionary

### DIFF
--- a/src/differential/revision/ArcanistDifferentialRevisionRef.php
+++ b/src/differential/revision/ArcanistDifferentialRevisionRef.php
@@ -28,7 +28,7 @@ class ArcanistDifferentialRevisionRef {
   protected $statusName;
   protected $sourcePath;
 
-  public function newFromDictionary(array $dictionary) {
+  public static function newFromDictionary(array $dictionary) {
     $ref = new ArcanistDifferentialRevisionRef();
     $ref->id         = $dictionary['id'];
     $ref->name       = $dictionary['name'];


### PR DESCRIPTION
Marked ArcanistDifferentialRevisionRef::newFromDictionary as a static method to statisfy E_STRICT standard

Without this, `arc commit` displays notifications when php errors are set to E_STRICT.
