### PR TITLE
Fix phutil_analyzer bug on interface dependency creation

### DIFF
--- a/scripts/phutil_analyzer.php
+++ b/scripts/phutil_analyzer.php
@@ -303,7 +303,7 @@ foreach (Futures($futures) as $file => $future) {
       $extends = $interface->getChildByIndex(2);
       foreach ($extends->selectDescendantsOfType('n_CLASS_NAME') as $parent) {
         $requirements->addInterfaceDependency(
-          $class_name->getConcreteString(),
+          $interface_name->getConcreteString(),
           $parent,
           $parent->getConcreteString());
       }


### PR DESCRIPTION
Summary:
Use $interface_name instead of $class_name when dealing with
interfaces. Problem happens when you extend an interface:

```
interface SubIface extends SuperIface { ...

Notice: Undefined variable: class_name in ...
Fatal error: Call to a member function getConcreteString() on a
non-object in ...
```

Test Plan: phutil_mapper.php works!
