### PR TITLE
Pull request for differential revision D1052

### DIFF
--- a/src/workflow/mark-committed/__init__.php
+++ b/src/workflow/mark-committed/__init__.php
@@ -7,6 +7,7 @@
 
 
 phutil_require_module('arcanist', 'exception/usage');
+phutil_require_module('arcanist', 'exception/usage/userabort');
 phutil_require_module('arcanist', 'workflow/base');
 
 phutil_require_module('phutil', 'console');


### PR DESCRIPTION
Test Plan:
Run `arc mark-committed` on a revision that you don't own, you should see a
prompt asking you if you really want to do that and if you answer `Y` it should
mark the revision as committed.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, epriestley, mareksapota

Differential Revision: 1052
