### PR TITLE
Added support to bash-completion for zsh

### DIFF
--- a/resources/shell/bash-completion
+++ b/resources/shell/bash-completion
@@ -1,3 +1,7 @@
+if [[ -n ${ZSH_VERSION-} ]]; then
+  autoload -U +X bashcompinit && bashcompinit
+fi
+
 _arc ()
 {
   CUR="${COMP_WORDS[COMP_CWORD]}"


### PR DESCRIPTION
I've added support to the bash-completion file to work with zsh.
