### PR TITLE
Fix for install-certificate workflow premature timeout.

### DIFF
--- a/src/workflow/install-certificate/ArcanistInstallCertificateWorkflow.php
+++ b/src/workflow/install-certificate/ArcanistInstallCertificateWorkflow.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2011 Facebook, Inc.
+ * Copyright 2012 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,6 @@ EOTEXT
 
     echo "Trying to connect to server...\n";
     $conduit = new ConduitClient($uri);
-    $conduit->setTimeout(5);
     try {
       $conduit->callMethodSynchronous('conduit.ping', array());
     } catch (Exception $ex) {


### PR DESCRIPTION
Accepted in D1404 - https://secure.phabricator.com/D1404
