### PR TITLE
Git tempfile fix

### DIFF
--- a/src/repository/api/git/ArcanistGitAPI.php
+++ b/src/repository/api/git/ArcanistGitAPI.php
@@ -412,9 +412,12 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
   }
 
   public function amendGitHeadCommit($message) {
+    $this->writeScratchFile("ammend-message", $message);
+    $scratch_path = $this->getScratchFilePath("ammend-message");
     $this->execxLocal(
-      'commit --amend --allow-empty --message %s',
-      $message);
+      'commit --amend --allow-empty -F %s',
+      $scratch_path);
+    $this->removeScratchFile("ammend-message");
   }
 
   public function getPreReceiveHookStatus($old_ref, $new_ref) {


### PR DESCRIPTION
Use a scratch file when running git commit --amend to avoid shell escaping issues on windows.
