### PR TITLE
Make arc diff not crash on hg bookmarks

### DIFF
--- a/src/repository/parser/mercurial/ArcanistMercurialParser.php
+++ b/src/repository/parser/mercurial/ArcanistMercurialParser.php
@@ -176,6 +176,9 @@ final class ArcanistMercurialParser {
           case 'tag':
             $commit['tag'] = $value;
             break;
+          case 'bookmark':
+            $commit['bookmark'] = $value;
+            break;
           default:
             throw new Exception("Unknown Mercurial log field '{$name}'!");
         }


### PR DESCRIPTION
Using mercurial bookmarks and trying to run `arc diff` gave me this:

```
Exception:
Unknown Mercurial log field 'bookmark'!
(Run with --trace for a full exception trace.)
```

See: http://mercurial.selenic.com/wiki/BookmarksExtension

Not sure whether I should attach it to the `$commit` or just drop it - it isn't being used anywhere else right now
