### PR TITLE
Make arc diff work with multiple heads in hg

### DIFF
--- a/src/repository/api/mercurial/ArcanistMercurialAPI.php
+++ b/src/repository/api/mercurial/ArcanistMercurialAPI.php
@@ -174,7 +174,7 @@ final class ArcanistMercurialAPI extends ArcanistRepositoryAPI {
         "{node}\1{rev}\1{author}\1{date|rfc822date}\1".
           "{branch}\1{tag}\1{parents}\1{desc}\2",
         $this->getRelativeCommit(),
-        $this->getWorkingCopyRevision().':0',
+        "ancestors({$this->getWorkingCopyRevision()})",
         $this->getBranchName());
       $logs = array_filter(explode("\2", $info));
 


### PR DESCRIPTION
When you have a commit history that looks like this:

```
@  11805 foo (bookmark: foo, not pushed)
|
| o  11804 bar (bookmark: bar, not pushed)
|/
o  11803 baz (already pushed)
```

If you're on `foo` (i.e. `hg update 11805`), and run arc diff, the diff that shows up on differential is correct, but the list of commits will contain both `foo` and `bar`.

This is because `11805:0` contains `11804`. We actually only want things that are ancestors of the current revision, which we can get with `ancestor(11805)` instead.

These heads are the same hg branch, but are identified by different hg bookmarks (which are like lightweight git branches).
