### PR TITLE
Filename linter fix for Windows

### DIFF
--- a/src/lint/linter/filename/ArcanistFilenameLinter.php
+++ b/src/lint/linter/filename/ArcanistFilenameLinter.php
@@ -44,7 +44,7 @@ final class ArcanistFilenameLinter extends ArcanistLinter {
   }
 
   public function lintPath($path) {
-    if (!preg_match('@^[a-z0-9./_-]+$@i', $path)) {
+    if (!preg_match('@^[a-z0-9./\\\\_-]+$@i', $path)) {
       $this->raiseLintAtPath(
         self::LINT_BAD_FILENAME,
         'Name files using only letters, numbers, period, hyphen and '.


### PR DESCRIPTION
Summary: On windows paths are separated with .

Test Plan: - Run filename linter on windows (or some path with )

Reviewers: epriestley

CC: aran, Koolvin

Differential Revision: https://secure.phabricator.com/D2559
