### PR TITLE
Simplify phpunit test names

### DIFF
--- a/src/unit/engine/phpunit/PhpunitTestEngine.php
+++ b/src/unit/engine/phpunit/PhpunitTestEngine.php
@@ -188,13 +188,7 @@ final class PhpunitTestEngine extends ArcanistBaseUnitTestEngine {
         }
       }
 
-      $pos = strpos($event->suite, '::');
-      if ($pos === false) {
-        $name = substr($event->test, strlen($event->suite) + 2);
-      } else {
-        $name = substr($event->test, $pos + 2);
-        $name = preg_replace('/ \(array\(.*\)\)/', '', $name);
-      }
+      $name = preg_replace('/ \(.*\)/', '', $event->test);
 
       $result = new ArcanistUnitTestResult();
       $result->setName($name);


### PR DESCRIPTION
Summary:
More & more use cases come up with empty suite names, guessing
and making test names nice is mess. Will leave it as it is, except
data set part, as it could be super long.

Test Plan: - Try running some phpunit tests with & without data sets

Reviewers: epriestley

CC: aran, Koolvin

Differential Revision: https://secure.phabricator.com/D2544
