### PR TITLE
Support mutable history in mercurial for arc diff and arc amend

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -459,7 +459,7 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
     return $this->status;
   }
 
-  public function amendGitHeadCommit($message) {
+  public function amendCommit($message) {
     $tmp_file = new TempFile();
     Filesystem::writeFile($tmp_file, $message);
     $this->execxLocal(
@@ -679,6 +679,14 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
   public function getWorkingCopyRevision() {
     list($stdout) = $this->execxLocal('rev-parse HEAD');
     return rtrim($stdout, "\n");
+  }
+
+  public function isHistoryDefaultImmutable() {
+    return false;
+  }
+
+  public function supportsAmend() {
+    return true;
   }
 
   public function supportsRelativeLocalCommits() {

--- a/src/repository/api/ArcanistRepositoryAPI.php
+++ b/src/repository/api/ArcanistRepositoryAPI.php
@@ -170,12 +170,18 @@ abstract class ArcanistRepositoryAPI {
   abstract public function getLocalCommitInformation();
   abstract public function getSourceControlBaseRevision();
   abstract public function getCanonicalRevisionName($string);
+  abstract public function isHistoryDefaultImmutable();
+  abstract public function supportsAmend();
   abstract public function supportsRelativeLocalCommits();
   abstract public function getWorkingCopyRevision();
   abstract public function updateWorkingCopy();
   abstract public function loadWorkingCopyDifferentialRevisions(
     ConduitClient $conduit,
     array $query);
+
+  public function amendCommit() {
+    throw new ArcanistCapabilityNotSupportedException($this);
+  }
 
   public function getAllBranches() {
     // TODO: Implement for Mercurial/SVN and make abstract.

--- a/src/repository/api/ArcanistSubversionAPI.php
+++ b/src/repository/api/ArcanistSubversionAPI.php
@@ -507,6 +507,14 @@ EODIFF;
     return null;
   }
 
+  public function isHistoryDefaultImmutable() {
+    return true;
+  }
+
+  public function supportsAmend() {
+    return false;
+  }
+
   public function supportsRelativeLocalCommits() {
     return false;
   }

--- a/src/workflow/ArcanistBaseWorkflow.php
+++ b/src/workflow/ArcanistBaseWorkflow.php
@@ -1027,8 +1027,15 @@ abstract class ArcanistBaseWorkflow {
   }
 
   protected function isHistoryImmutable() {
+    $repository_api = $this->getRepositoryAPI();
     $working_copy = $this->getWorkingCopy();
-    return ($working_copy->getConfig('immutable_history') === true);
+
+    $project_config = $working_copy->getConfig('immutable_history');
+    if ($project_config !== null) {
+      return $project_config;
+    }
+
+    return $repository_api->isHistoryDefaultImmutable();
   }
 
   /**

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -473,12 +473,15 @@ EOTEXT
             'revision_id' => $result['revisionid'],
           ));
 
-        if (!$this->isRawDiffSource()) {
+        if (!$this->isRawDiffSource() && $this->shouldAmend()) {
           $repository_api = $this->getRepositoryAPI();
-          if (($repository_api instanceof ArcanistGitAPI) &&
-              $this->shouldAmend()) {
+
+          if ($repository_api->supportsAmend()) {
             echo "Updating commit message...\n";
-            $repository_api->amendGitHeadCommit($revised_message);
+            $repository_api->amendCommit($revised_message);
+          } else {
+            echo "Commit message was not amended. Amending commit message is ".
+                 "only supported in git and hg (version 2.2 or newer)";
           }
         }
 


### PR DESCRIPTION
Summary:
This adds basic support for mutable history for arc diff and arc amend for
mercurial. This is purely opt-in (so it shouldn't affect anyone who doesn't want
this feature) by explicitly setting

```
"immutable_history" : false
```

in arc configuration.

This also fixes another instance of weird behaviour for multiple heads - the
first instance was fixed here:
https://github.com/facebook/arcanist/pull/28

Test Plan:
without "immutable_history" turned on)>

When ##arc diff## produces an update diff, it should list only commits that are
ancestors of the current revision - not ones from other heads.

Reviewers: epriestley

CC: csilvers, aran, Koolvin

Differential Revision: https://secure.phabricator.com/D2654
