### PR TITLE
Use .^ instead of HEAD^ for mercurial

### DIFF
--- a/src/workflow/ArcanistAmendWorkflow.php
+++ b/src/workflow/ArcanistAmendWorkflow.php
@@ -102,7 +102,11 @@ EOTEXT
       $revision_id = $this->normalizeRevisionID($this->getArgument('revision'));
     }
 
-    $repository_api->setRelativeCommit('HEAD^');
+    if ($repository_api instanceof ArcanistGitAPI) {
+      $repository_api->setRelativeCommit('HEAD^');
+    } else if ($repository_api instanceof ArcanistMercurialAPI) {
+      $repository_api->setRelativeCommit('.^');
+    }
 
     $in_working_copy = $repository_api->loadWorkingCopyDifferentialRevisions(
       $this->getConduit(),


### PR DESCRIPTION
Summary:
## arc amend## in a mercurial repo was failing with this message

```
Usage Exception: Commit 'HEAD^' is not a valid Mercurial commit identifier.
```

mercurial's .^ is about the same thing as git's HEAD^

Test Plan:
## arc amend## in a mercurial repo with ##"immutable_history" : "false"## in the
## .arcconfig##.

Reviewers: epriestley

Reviewed By: epriestley

CC: vrana, aran, Korvin

Differential Revision: https://secure.phabricator.com/D2690
