### PR TITLE
Fix help message for arc tasks --status

### DIFF
--- a/src/workflow/ArcanistTasksWorkflow.php
+++ b/src/workflow/ArcanistTasksWorkflow.php
@@ -56,7 +56,7 @@ EOTEXT
     return array(
       'status' => array(
         'param' => 'task_status',
-        'help' => "Show tasks that or open or closed, default is all.",
+        'help' => "Show tasks that or open or closed, default is open.",
       ),
       'owner' => array(
         'param' => 'username',


### PR DESCRIPTION
From https://github.com/facebook/arcanist/blob/master/src/workflow/ArcanistTasksWorkflow.php#L173

`$find_params['status'] = ($status?"status-".$status:"status-open");`
