### PR TITLE
Specify error severity for some PyFlakes messages

### DIFF
--- a/src/lint/linter/ArcanistPyFlakesLinter.php
+++ b/src/lint/linter/ArcanistPyFlakesLinter.php
@@ -100,12 +100,19 @@ final class ArcanistPyFlakesLinter extends ArcanistLinter {
       foreach ($matches as $key => $match) {
         $matches[$key] = trim($match);
       }
+
+      $severity = ArcanistLintSeverity::SEVERITY_WARNING;
+      $description = $matches[3];
+      if (preg_match('/(^undefined|^duplicate|before assignment$)/', $description)) {
+        $severity = ArcanistLintSeverity::SEVERITY_ERROR;
+      }
+
       $message = new ArcanistLintMessage();
       $message->setPath($path);
       $message->setLine($matches[2]);
       $message->setCode($this->getLinterName());
-      $message->setDescription($matches[3]);
-      $message->setSeverity(ArcanistLintSeverity::SEVERITY_WARNING);
+      $message->setDescription($description);
+      $message->setSeverity($severity);
       $this->addLintMessage($message);
     }
   }


### PR DESCRIPTION
Since PyFlakes has no internal demarcation of errors and warnings, running arc lint without the `lintall` option specified results in missing syntax errors and other important messages since ArcanistPyFlakesLinter specifies all messages as `ArcanistLintSeverity::SEVERITY_WARNING`. This pull request marks some messages as SEVERITY_ERROR based on an internal regex. There was some talk of making this a user-specified option in .arcconfig, but this, to me, puts too much onus on individual developers. I'd be open to making it overridable through arcconfig, but I think the linter itself should have some opinion about what constitutes an error.
