### PR TITLE
Adding confirmation message to 'arc todo' with information about the task created

### DIFF
--- a/src/workflow/ArcanistTodoWorkflow.php
+++ b/src/workflow/ArcanistTodoWorkflow.php
@@ -90,9 +90,15 @@ EOTEXT
       $args['ccPHIDs'] = $phids;
     }
 
-    $conduit->callMethodSynchronous(
+    $result = $conduit->callMethodSynchronous(
       'maniphest.createtask',
       $args);
+
+    echo phutil_console_format(
+      "Created task T%s: '<fg:green>**%s**</fg>' at <fg:blue>**%s**</fg>\n",
+      $result['id'],
+      $result['title'],
+      $result['uri']);
   }
 
 }


### PR DESCRIPTION
Summary: 'arc todo' now logs a message with the task title and URI when run.

Test Plan: Run 'arc todo test' and see that it logs a message with the form 'Created task <task number>: '<task title' at <task URI>

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3016
