### PR TITLE
JSHint linter issue on windows

### DIFF
--- a/src/lint/linter/ArcanistJSHintLinter.php
+++ b/src/lint/linter/ArcanistJSHintLinter.php
@@ -116,7 +116,8 @@ final class ArcanistJSHintLinter extends ArcanistLinter {
     }
 
     // Look for globally installed JSHint
-    list($err) = exec_manual('which %s', $bin);
+    $cmd = (phutil_is_windows()) ? 'where %s' : 'which %s';
+    list($err) = exec_manual($cmd, $bin);
     if ($err) {
       throw new ArcanistUsageException(
         "JSHint does not appear to be installed on this system. Install it ".


### PR DESCRIPTION
Summary: On windows there is no 'which', only 'where'

Test Plan: Run JSHint linter on windows and unix-like system.

Reviewers: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3096
