### PR TITLE
Fix getCommitMessage to properly separate subject and body with 2 newlines

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -753,7 +753,7 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
   public function getCommitMessage($commit) {
     list($message) = $this->execxLocal(
       'log -n1 --format=%C %s --',
-      '%s%n%b',
+      '%s%n%n%b',
       $commit);
     return $message;
   }


### PR DESCRIPTION
Git commit messages must have 2 newlines between the subject and body
If used to rewrite a commit message then the commit message will be
incorrectly reformatted.
