### PR TITLE
Fixed git branch name contains color

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -336,7 +336,7 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
     //    $ git rev-parse --abbrev-ref `git symbolic-ref HEAD`
     //
     // But that may fail if you're not on a branch.
-    list($stdout) = $this->execxLocal('branch');
+    list($stdout) = $this->execxLocal('branch --no-color');
 
     $matches = null;
     if (preg_match('/^\* (.+)$/m', $stdout, $matches)) {


### PR DESCRIPTION
The repository api `getBranchName` in git doesn't use `--no-color` option,so it will contains color character in some shell when you configure color (in my mac terminal for example) such as `[32mmybranch[m`,then it will corrupt the `arc land` process because the branch name is wrong.
