### PR TITLE
phpunit fix

### DIFF
--- a/src/unit/engine/PhpunitTestEngine.php
+++ b/src/unit/engine/PhpunitTestEngine.php
@@ -126,8 +126,7 @@ final class PhpunitTestEngine extends ArcanistBaseUnitTestEngine {
       );
     }
 
-    $json = str_replace('}{"', '},{"', $json);
-    $json = str_replace('}{', '},{', $json);
+    $json = preg_replace('/}{\s*"/', '},{"', $json);
     $json = '[' . $json . ']';
     $json = json_decode($json);
     if (!is_array($json)) {


### PR DESCRIPTION
PHPUnit 3.7.7 generates json logs like this:

```
{
    "event": "suiteStart",
    "suite": "QueryGenTest",
    "tests": 6
}{
    "event": "testStart",
```

Json report preprocessor (which adds commas between `}{` and `[ ]` around it) needs to be fixed to match it.
