### PR TITLE
Fix for a tiny bug where `arc land` will fail if a branch has the same name a file path in the root of the repo.

### DIFF
--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -353,7 +353,7 @@ EOTEXT
 
     if ($repository_api instanceof ArcanistGitAPI) {
       list($out) = $repository_api->execxLocal(
-        'log --oneline %s %s',
+        'log --oneline %s %s --',
         $this->branch,
         '^'.$this->onto);
     } else if ($repository_api instanceof ArcanistMercurialAPI) {


### PR DESCRIPTION
(In fbcode and www at least, the only places I tried) if a
branch happens to be named the same as a file path (from root) (like if
a branch is called `spec` and there is a directory in `www` called
`spec`) then `arc land` will fail with git complaining that the argument
(to `git log ...`) is ambiguous as it could refer to both a path and a
revision; so this diff adds a `--` to the end so that git knows that
both are revisions and not paths.

Test Plan: Try and land something from www (I did, see D752219) where
the branch is named `spec`.

Reviewers:

CC:

Task ID: #

Blame Rev:
