### PR TITLE
Negate commit add-unstaged-files question

### DIFF
--- a/src/workflow/ArcanistBaseWorkflow.php
+++ b/src/workflow/ArcanistBaseWorkflow.php
@@ -816,8 +816,8 @@ abstract class ArcanistBaseWorkflow extends Phobject {
           $api->addToCommit($untracked);
           $must_commit += array_flip($untracked);
         } else if ($this->commitMode == self::COMMIT_DISABLE) {
-          $prompt = "Do you want to continue without adding these files?";
-          if (!phutil_console_confirm($prompt, $default_no = false)) {
+          $prompt = "Do you want to add these files before continuing?";
+          if (phutil_console_confirm($prompt)) {
             throw new ArcanistUserAbortException();
           }
         }


### PR DESCRIPTION
Summary:
The add-unstaged-files question arc asks differs in positivity in
different workflows. `arc diff` asks "Do you want to add the files
before continuing", while `arc land` asks "Do you want to continue
without adding?".

This normalizes the questions to have the same "positivity".
Specifically, it negates the `arc land` workflow, because that seemed a
little more isolated.

Test Plan:
Touch a file, run both `arc diff --preview` and `arc land --preview`
