### PR TITLE
Use underscores instead of hyphens as bookmark suffixes.

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -255,7 +255,7 @@ EOTEXT
       $base_name .= "-D{$revision_id}";
     }
 
-    $suffixes = array(null, '-1', '-2', '-3');
+    $suffixes = array(null, '_1', '_2', '_3');
     foreach ($suffixes as $suffix) {
       $proposed_name = $base_name.$suffix;
 


### PR DESCRIPTION
When trying to find an unused bookmark we append hyphened suffixes to the end of the bookmark name. In Mercurial, these are treated the same as the bookmark name without the suffix, here's the output from hg log -r:

```
[mehdi] HGPLAIN=1 hg log -r "arcpatch-1"
abort: unknown revision 'arcpatch'!
[mehdi] HGPLAIN=1 hg log -r "arcpatch_1"
abort: unknown revision 'arcpatch_1'!
```
