### PR TITLE
Filter out messages from included files

### DIFF
--- a/src/lint/linter/ArcanistCppcheckLinter.php
+++ b/src/lint/linter/ArcanistCppcheckLinter.php
@@ -96,6 +96,9 @@ final class ArcanistCppcheckLinter extends ArcanistLinter {
         continue;
       }
       $file = $location->getAttribute('file');
+      if ($file != Filesystem::resolvePath($this->getActivePath())) {
+        continue;
+      }
       $line = $location->getAttribute('line');
 
       $id = $error->getAttribute('id');


### PR DESCRIPTION
CppCheck shows lint messages from included files as well as the current
file. Filter out those, since they don't make much sense in the context
of `arc lint`.
