### PR TITLE
Force the locale to English.

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -22,7 +22,11 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
 
   protected function buildLocalFuture(array $argv) {
 
-    $argv[0] = 'LANG=C git '.$argv[0];
+    if (phutil_is_windows()) {
+        $argv[0] = 'set LANG=C & git '.$argv[0];
+    } else {
+        $argv[0] = 'LANG=C git '.$argv[0];
+    }
 
     $future = newv('ExecFuture', $argv);
     $future->setCWD($this->getPath());

--- a/src/repository/api/ArcanistSubversionAPI.php
+++ b/src/repository/api/ArcanistSubversionAPI.php
@@ -40,7 +40,11 @@ final class ArcanistSubversionAPI extends ArcanistRepositoryAPI {
 
   protected function buildLocalFuture(array $argv) {
 
-    $argv[0] = 'LANG=C svn '.$argv[0];
+    if (phutil_is_windows()) {
+        $argv[0] = 'set LANG=C & svn '.$argv[0];
+    } else {
+        $argv[0] = 'LANG=C svn '.$argv[0];
+    }
 
     $future = newv('ExecFuture', $argv);
     $future->setCWD($this->getPath());


### PR DESCRIPTION
svn and git are localized and the parsing was failing [1] when 'svn info' was performed in French [2].

[1]
[...]

> > > [21] <exec> $ svn info '/data/pkg-llvm/clang.svn/test/Driver/clang_f_opts.c'@
> > > <<< [18] <exec> 265,878 us
> > > <<< [16] <exec> 280,405 us
> > > <<< [19] <exec> 331,980 us
> > > <<< [21] <exec> 347,814 us
> > > <<< [17] <exec> 369,468 us
> > > <<< [15] <exec> 377,656 us
> > > <<< [14] <exec> 383,733 us
> > > <<< [20] <exec> 373,991 us

[2013-11-11 13:25:22] EXCEPTION: (Exception) Unable to parse SVN info. at [/data/pkg-llvm/arcanist/src/repository/api/ArcanistSubversionAPI.php:357]
  #0 ArcanistSubversionAPI::getSVNInfo(include/clang/Basic/DiagnosticDriverKinds.td) called at [/data/pkg-llvm/arcanist/src/parser/ArcanistDiffParser.php:93]
  #1 ArcanistDiffParser::parseSubversionDiff(Object ArcanistSubversionAPI, Array of size 4 starting with: { include/clang/Basic/DiagnosticDriverKinds.td => 1 }) called at [/data/pkg-llvm/arcanist/src/workflow/ArcanistDiffWorkflow.php:936]
  #2 ArcanistDiffWorkflow::generateChanges() called at [/data/pkg-llvm/arcanist/src/workflow/ArcanistDiffWorkflow.php:504]
  #3 ArcanistDiffWorkflow::run() called at [/data/pkg-llvm/arcanist/scripts/arcanist.php:318]

[2] $ svn info
Chemin : .
Chemin racine de la copie de travail : /data/pkg-llvm/clang.svn
URL : https://bar@llvm.org/svn/llvm-project/cfe/trunk
Racine du dépôt : https://bar@llvm.org/svn/llvm-project
UUID du dépôt : 91177308-0d34-0410-b5e6-96231b3b80d8
Révision : 194373
Type de nœud : répertoire
Tâche programmée : normale
Auteur de la dernière modification : foo
Révision de la dernière modification : 194368
Date de la dernière modification: 2013-11-11 07:36:33 +0100 (lun. 11 nov. 2013)
