### PR TITLE
ArcanistGitAPI: remove a bogus comment

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -473,9 +473,6 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
         'ls-files --others --exclude-standard',
       ));
 
-    // TODO: This doesn't list unstaged adds. It's not clear how to get that
-    // list other than "git status --porcelain" and then parsing it. :/
-
     // Unstaged changes
     $unstaged_future = $this->buildLocalFuture(
       array(


### PR DESCRIPTION
It's unclear what an "unstaged add" is, and the author of 628de7d (Make
all the working-copy-paths errors extremely explicit., 2011-03-12)
admits this as well.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
