### PR TITLE
ArcanistGitAPI: document a git ls-files bug

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -477,6 +477,8 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
     // list other than "git status --porcelain" and then parsing it. :/
 
     // Unstaged changes
+    // TODO: This doesn't exclude ignored submodules.
+    // Upstream bug: http://thread.gmane.org/gmane.comp.version-control.git/238173
     $unstaged_future = $this->buildLocalFuture(
       array(
         'ls-files -m',


### PR DESCRIPTION
When a submodule is ignored (ignore=all in .gitconfig),

  $ git ls-files -m

fails to exclude the submodule from the listing. Other commands like

  $ git diff-index --name-only HEAD

exclude it just fine.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
