### PR TITLE
ArcanistGitAPI: replace 'ls-files -m' with diff-files

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -474,11 +474,9 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
       ));
 
     // Unstaged changes
-    // TODO: This doesn't exclude ignored submodules.
-    // Upstream bug: http://thread.gmane.org/gmane.comp.version-control.git/238173
     $unstaged_future = $this->buildLocalFuture(
       array(
-        'ls-files -m',
+        'diff-files --name-only',
       ));
 
     $futures = array(


### PR DESCRIPTION
As documented,

  $ git ls-files -m

fails to exclude ignored submodules. Replace it with an equivalent:

  $ git diff-files --name-only

which does not suffer from this defect.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
