### PR TITLE
Create arc config directory if it does not exist

### DIFF
--- a/src/workingcopyidentity/ArcanistWorkingCopyIdentity.php
+++ b/src/workingcopyidentity/ArcanistWorkingCopyIdentity.php
@@ -330,7 +330,7 @@ final class ArcanistWorkingCopyIdentity {
     $json = $json_encoder->encodeFormatted($config);
 
     $config_file = Filesystem::resolvePath('config', $dir);
-     try {
+    try {
       Filesystem::writeFile($config_file, $json);
     } catch (FilesystemException $ex) {
       return false;


### PR DESCRIPTION
It seems that `ArcanistWorkingCopyIdentity::writeLocalArcConfig` fails if the `.git/arc` (for example) directory does not exist. It seems logical to me that this directory should be created if it does not yet exist.
