### PR TITLE
Allow setting custom spelling data for `ArcanistSpellingLinter`

### DIFF
--- a/src/lint/linter/ArcanistSpellingLinter.php
+++ b/src/lint/linter/ArcanistSpellingLinter.php
@@ -19,9 +19,7 @@ final class ArcanistSpellingLinter extends ArcanistLinter {
 
   public function __construct($severity = self::LINT_SPELLING_PICKY) {
     $this->severity = $severity;
-    $this->wholeWordRules = ArcanistSpellingDefaultData::getFullWordRules();
-    $this->partialWordRules =
-      ArcanistSpellingDefaultData::getPartialWordRules();
+    $this->setSpellingData(new ArcanistSpellingDefaultData());
   }
 
   public function getLinterName() {
@@ -46,6 +44,11 @@ final class ArcanistSpellingLinter extends ArcanistLinter {
     $severity = self::LINT_SPELLING_IMPORTANT) {
 
     $this->wholeWordRules[$severity][$incorrect_word] = $correct_word;
+  }
+
+  public function setSpellingData(ArcanistSpellingDefaultData $spelling_data) {
+    $this->wholeWordRules = $spelling_data->getFullWordRules();
+    $this->partialWordRules = $spelling_data->getPartialWordRules();
   }
 
   public function getLintSeverityMap() {


### PR DESCRIPTION
The `ArcanistSpellingDefaultData` is non-final and can be extended (which is great), however there is no straight-forward way to use custom spelling data with the `ArcanistSpellingLinter`. Currently, something similar to this would need to be done:

```
$linter = id(new ArcanistSpellingLinter());

foreach (CustomSpellingData::getPartialWordRules() as $severity => $rules) {
  foreach ($rules as $incorrect_word => $correct_word) {
    $linter->addPartialWordRule($incorrect_word, $correct_word, $severity);
  }
}

foreach (CustomSpellingData::getFullWordRules() as $severity => $rules) {
  foreach ($rules as $incorrect_word => $correct_word) {
    $linter->addWholeWordRule($incorrect_word, $correct_word, $severity);
  }
}
```

The proposed changes allow a much nicer syntax:

```
$linter = id(new ArcanistSpellingLinter())
  ->setSpellingData(new CustomSpellingData());
```
