### PR TITLE
Csslint fixes

### DIFF
--- a/src/lint/linter/ArcanistCSSLintLinter.php
+++ b/src/lint/linter/ArcanistCSSLintLinter.php
@@ -86,7 +86,7 @@ final class ArcanistCSSLintLinter extends ArcanistExternalLinter {
         $message->setDescription($child->getAttribute('reason'));
         $message->setSeverity($severity);
 
-        if ($child->hasAttribute('line')) {
+        if ($child->hasAttribute('line') && $child->getAttribute('line') > 0) {
           $line = $lines[$child->getAttribute('line') - 1];
           $text = substr($line, $child->getAttribute('char') - 1);
           $message->setOriginalText($text);


### PR DESCRIPTION
It looks like the behaviour of `csslint` has changed since the `ArcanistCSSLintLinter` was written. Consequently, `ArcanistCSSLintLinter` does not work with the latest version of `csslint` (v0.10.0).

Whilst the proposed changes work for v0.10.0, it may be more challenging to ensure that these changes don't break with older versions of `csslint`.
