### PR TITLE
Allow tests to be executed in the root library directory

### DIFF
--- a/src/unit/engine/PhutilUnitTestEngine.php
+++ b/src/unit/engine/PhutilUnitTestEngine.php
@@ -81,7 +81,7 @@ final class PhutilUnitTestEngine extends ArcanistBaseUnitTestEngine {
 
     $run_tests = array();
     foreach ($symbols as $symbol) {
-      if (!preg_match('@/__tests__/@', $symbol['where'])) {
+      if (!preg_match('@(?:^|/)__tests__/@', $symbol['where'])) {
         continue;
       }
 


### PR DESCRIPTION
Currently, `ArcanistPhutilTestCase` that exist in `src/__tests__/` will not be executed by `PhutilUnitTestEngine`. This pull request fixes this.
