### PR TITLE
Fix exception on diff parse on FreeBSD

### DIFF
--- a/src/parser/ArcanistDiffParser.php
+++ b/src/parser/ArcanistDiffParser.php
@@ -220,7 +220,7 @@ final class ArcanistDiffParser {
         '(?P<type>rcsdiff -u) (?P<oldnew>.*)',
         // This is a unified diff, probably from "diff -u" or synthetic diffing.
         '(?P<type>---) (?P<old>.+)\s+\d{4}-\d{2}-\d{2}.*',
-        '(?P<binary>Binary) files '.
+        '(?P<binary>Binary files|Files) '.
           '(?P<old>.+)\s+\d{4}-\d{2}-\d{2} and '.
           '(?P<new>.+)\s+\d{4}-\d{2}-\d{2} differ.*',
         // This is a normal Mercurial text change, probably from "hg diff". It


### PR DESCRIPTION
FreeBSD 9.2 comes with diff tool version 2.8.7 which behaves
a bit different from how it is expected to. Namely for diff
between two binary files it says:

  Files A and B are differ

This was leading to an exception when browsing revisions with
changes in binary files.

Tweaked parse patterns in order to fix this issue. Now both
older and newer diff tools are supported.
