### PR TITLE
Use system default LANG if en_US.{utf8,UTF-8} are not available

### DIFF
--- a/src/workflow/ArcanistCommitWorkflow.php
+++ b/src/workflow/ArcanistCommitWorkflow.php
@@ -294,6 +294,11 @@ EOTEXT
       $locales = array_fill_keys($locales, true);
       if (isset($locales['en_US.UTF-8'])) {
         $locale = 'en_US.UTF-8';
+      } elseif (isset($locales['en_US.utf8'])) {
+        $locale = 'en_US.utf8';
+      } else {
+        // If en_US is not available, use system default
+        $locale = $_ENV['LANG'];
       }
     } catch (Exception $ex) {
       // Ignore.


### PR DESCRIPTION
Prevents svn warnings on our hosts where en_US locale is not present.
