### PR TITLE
[repository] Add custom working revision

### DIFF
--- a/src/repository/api/ArcanistRepositoryAPI.php
+++ b/src/repository/api/ArcanistRepositoryAPI.php
@@ -331,7 +331,7 @@ abstract class ArcanistRepositoryAPI {
     ConduitClient $conduit,
     array $query);
   abstract public function getRemoteURI();
-
+  abstract public function setWorkingRevision($revision);
 
   public function getUnderlyingWorkingCopyRevision() {
     return $this->getWorkingCopyRevision();

--- a/src/workflow/ArcanistBaseWorkflow.php
+++ b/src/workflow/ArcanistBaseWorkflow.php
@@ -72,12 +72,13 @@ abstract class ArcanistBaseWorkflow extends Phobject {
   private $parentWorkflow;
   private $workingDirectory;
   private $repositoryVersion;
+  private $workingRevision;
 
   private $changeCache = array();
 
 
   public function __construct() {
-
+    $this->workingRevision = 'HEAD';
   }
 
 
@@ -544,6 +545,15 @@ abstract class ArcanistBaseWorkflow extends Phobject {
     return array();
   }
 
+  public function setWorkingRevision($revision)
+  {
+    $this->workingRevision = $revision;
+    if ($this->repositoryAPI) {
+      $this->repositoryAPI->setWorkingRevision($revision);
+    }
+    return $this;
+  }
+
   public function setWorkingDirectory($working_directory) {
     $this->workingDirectory = $working_directory;
     return $this;
@@ -753,6 +763,7 @@ abstract class ArcanistBaseWorkflow extends Phobject {
 
   public function setRepositoryAPI($api) {
     $this->repositoryAPI = $api;
+    $api->setWorkingRevision($this->workingRevision);
     return $this;
   }
 


### PR DESCRIPTION
The repository API can be made more useful by working not only on the current HEAD, but working on a custom working revision.  this allows workflows to take a branch name as an argument and use that as a basis for workflows like arc diff.
