### PR TITLE
improve the Pylint regex - the existing regex was not returning any resu...

### DIFF
--- a/src/lint/linter/ArcanistPyLintLinter.php
+++ b/src/lint/linter/ArcanistPyLintLinter.php
@@ -221,7 +221,7 @@ final class ArcanistPyLintLinter extends ArcanistLinter {
     foreach ($lines as $line) {
       $matches = null;
       if (!preg_match(
-              '/([A-Z]\d+): *(\d+)(?:|,\d*): *(.*)$/',
+              '/^([A-Z]):\s{0,2}(\d{1,}),[-|\s]?\d+(?:|,\d*): *(.*)$/',
               $line, $matches)) {
         continue;
       }


### PR DESCRIPTION
...lts for v1.1.0 

it handles:

```
C:  1, 0: message
C: 74,12: message
W: 82,-1: message
R:174, 4: message
C:1565,1254: message
```
