### PR TITLE
added 'revision created' event

### DIFF
--- a/src/events/constant/ArcanistEventType.php
+++ b/src/events/constant/ArcanistEventType.php
@@ -10,6 +10,7 @@ final class ArcanistEventType extends PhutilEventType {
   const TYPE_DIFF_WASCREATED        = 'diff.wasCreated';
 
   const TYPE_REVISION_WILLCREATEREVISION = 'revision.willCreateRevision';
+  const TYPE_REVISION_CREATED            = 'revision.created';
 
   const TYPE_LAND_WILLPUSHREVISION  = 'land.willPushRevision';
 }


### PR DESCRIPTION
I needed to integrate Phabricator with youtrack to notify on newly created revisions.
Don't you mind if I add some new events? I started w/ `revision.created`.
