### PR TITLE
[easy] augument to argument

### DIFF
--- a/src/lint/linter/spelling/ArcanistSpellingDefaultData.php
+++ b/src/lint/linter/spelling/ArcanistSpellingDefaultData.php
@@ -520,7 +520,7 @@ class ArcanistSpellingDefaultData {
        "requrie" => "require",
        "existant" => "existent",
        "explict" => "explicit",
-       "agument" => "augument",
+       "agument" => "argument",
        "destionation" => "destination",
      ), array(
        'teh' => 'the'


### PR DESCRIPTION
It looks like the word `argument` appears many more times than `augment`, so I'm assuming `agument` is most likely to be a typo of `argument`.
