### PR TITLE
Accept int as map key too

### DIFF
--- a/src/lint/linter/ArcanistLinter.php
+++ b/src/lint/linter/ArcanistLinter.php
@@ -303,7 +303,7 @@ abstract class ArcanistLinter {
 
   public function getLinterConfigurationOptions() {
     return array(
-      'severity' => 'optional map<string, string>',
+      'severity' => 'optional map<string|int, string>',
       'severity.rules' => 'optional map<string, string>',
     );
   }


### PR DESCRIPTION
Accept integers in severity map too since when you pass the following

```
"text": {
    "type": "text",
    "include": "(\\.*)",
    "severity": {
        "3": "advice"
    }
}
```

to `.arclint` it throws an error. Reason is `json_decode` or PHP itself implicitly casting `"3"` into an integer `3`.
