### PR TITLE
fix base rule arc:upstream in windows environment

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -222,7 +222,7 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
 
     if (!$default_relative) {
       list($err, $upstream) = $this->execManualLocal(
-        "rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'");
+        "rev-parse --abbrev-ref --symbolic-full-name \"@{upstream}\"");
 
       if (!$err) {
         $default_relative = trim($upstream);


### PR DESCRIPTION
arcanist is using
rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'
to get the upstream branch.

however, unfortunately, single quotation is not working in windows
it would return error " fatal: No such branch: ''' "

change it to double quote can fix the issue.
