### PR TITLE
support for pylint through ArcanistConfigurationDrivenLintEngine

### DIFF
--- a/src/lint/linter/ArcanistPyLintLinter.php
+++ b/src/lint/linter/ArcanistPyLintLinter.php
@@ -51,6 +51,22 @@
  */
 final class ArcanistPyLintLinter extends ArcanistLinter {
 
+  public function getLinterConfigurationName() {
+      return 'pylint';
+  }
+
+  public function getInfoName() {
+      return 'pylint';
+  }
+
+  public function getInfoURI() {
+      return 'http://www.pylint.org/';
+  }
+
+  public function getInfoDescription() {
+      return pht('PyLint is a tool to to detect various errors in Python code');
+  }
+
   private function getMessageCodeSeverity($code) {
     $config = $this->getEngine()->getConfigurationManager();
 


### PR DESCRIPTION
since ArcanistConfigurationDrivenLintEngine->loadAvailableLinters() uses $linter->getLinterConfigurationName()
that method needs to exist in ArcanistPyLintLinter.php

adding these lines to .arcconfig
  "lint.engine": "ArcanistConfigurationDrivenLintEngine",
  "lint.pylint.codes.error":  "^[EF].*",
  "lint.pylint.codes.warning":  "^W.*",
  "lint.pylint.codes.advice":  "^[RC].*",
  "lint.pylint.rcfile": ".pylintrc"

and this to .arclint
    "pylint": {
      "type": "pylint",
      "include": "(\\.py$)"
    },

does the trick