### PR TITLE
Move README back to Markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-= WHAT IS ARCANIST? =
+## What is Arcanist?
 
-Arcanist is the command-line tool for [[http://phabricator.org/ | Phabricator]].
+Arcanist is the command-line tool for [Phabricator](http://phabricator.org).
 It allows you to interact with Phabricator installs to send code for review,
 download patches, transfer files, view status, make API calls, and various other
 things. You can find a complete user guide
-[[http://www.phabricator.com/docs/phabricator/article/Arcanist_User_Guide.html |
-here]].
+[here](http://www.phabricator.com/docs/phabricator/article/Arcanist_User_Guide.html).
 
 For more information about Phabricator, see http://phabricator.org/.
 
-= LICENSE =
+## License
 Arcanist is released under the Apache 2.0 license except as otherwise noted.


### PR DESCRIPTION
This file is Remarkup, but it doesn't display properly on GitHub. This diff moves it back to Markdown.