### PR TITLE
Add "hold" as a configuration option for the land flow

### DIFF
--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -319,6 +319,8 @@ EOTEXT
       $this->getUpstreamMatching($this->onto, '/^refs\/remotes\/(.+?)\//'),
       $remote_default);
     $this->remote = $this->getArgument('remote', $remote_default);
+	
+	$this->hold = $this->getArgument('hold') || $this->getConfigFromAnySource('arc.land.hold.default');
 
     if ($this->getArgument('merge')) {
       $this->useSquash = false;
@@ -1023,7 +1025,7 @@ EOTEXT
       throw $ex;
     }
 
-    if ($this->getArgument('hold')) {
+    if ($this->hold) {
       echo phutil_console_format(pht(
         'Holding change in **%s**: it has NOT been pushed yet.',
         $this->onto)."\n");


### PR DESCRIPTION
This change wasn't tested, but if you think it's valid you're welcome to approve it.

My intention was to be able to set a project-wide configuration that prevents "arc land" from pushing to origin. The developers in my company are used to do "arc land" but I want them to review their merge commit before they push it to the remote repository.