### PR TITLE
SVN: buildSyntheticAdditionDiff: exit sooner if path is a directory

### DIFF
--- a/src/repository/api/ArcanistSubversionAPI.php
+++ b/src/repository/api/ArcanistSubversionAPI.php
@@ -451,6 +451,10 @@ EODIFF;
   }
 
   protected function buildSyntheticAdditionDiff($path, $source, $rev) {
+    if (is_dir($this->getPath($path))) {
+      return null;
+    }
+
     $type = $this->getSVNProperty($path, 'svn:mime-type');
     if ($type == 'application/octet-stream') {
       return <<<EODIFF
@@ -460,10 +464,6 @@ Cannot display: file marked as a binary type.
 svn:mime-type = application/octet-stream
 
 EODIFF;
-    }
-
-    if (is_dir($this->getPath($path))) {
-      return null;
     }
 
     $data = Filesystem::readFile($this->getPath($path));


### PR DESCRIPTION
When doing svn copy, or svn mv, a SynthenticAdditionDiff is generated.

If the path is a directory, an error will occur when checking the
mime-type of the directory. Immediately after the properties check,
the function returns null if the path is a directory. Move this
check to before the properties check to avoid exiting with an error.

```
Command failed with error #1!
COMMAND
svn propget 'svn:mime-type' '/home/trasz/svn/ports/cad/py-pycam'@

STDOUT
(empty)

STDERR
svn: warning: W200017: Property 'svn:mime-type' not found on '/home/trasz/svn/ports/cad/py-pycam@'
svn: E200000: A problem occurred; see other errors for details

(Run with `--trace` for a full exception trace.)
```