### PR TITLE
Set current working directory as default directory AND set default language env

### DIFF
--- a/src/repository/api/ArcanistSubversionAPI.php
+++ b/src/repository/api/ArcanistSubversionAPI.php
@@ -40,6 +40,7 @@ final class ArcanistSubversionAPI extends ArcanistRepositoryAPI {
     $argv[0] = 'svn '.$argv[0];
 
     $future = newv('ExecFuture', $argv);
+    $future->setEnv(array('LANG'=>'en_US.UTF-8'));
     $future->setCWD($this->getPath());
     return $future;
   }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -685,7 +685,12 @@ EOTEXT
         $this->setCommitMode(self::COMMIT_ALLOW);
       }
       if ($repository_api instanceof ArcanistSubversionAPI) {
-        $repository_api->limitStatusToPaths($this->getArgument('paths'));
+		if($this->getArgument('paths')){
+		  $repository_api->limitStatusToPaths($this->getArgument('paths'));
+		} else {
+		  $currentPath[0] = getcwd();
+		  $repository_api->limitStatusToPaths($currentPath);
+		}
       }
       if (!$this->getArgument('head')) {
         $this->requireCleanWorkingCopy();


### PR DESCRIPTION
If working in a really big svn directory. arc diff will check all changes from root svn directory.  Which will cost a lot of time and include lots of changes should not include in one commit. 

Change it to current working directory will emit this con and following the default svn command action.

===========
While working in language other than english. svn info will generate strings can't parsed in regex patterns.  Leads to wrong svn info result.

set default language to english will fix it.