### PR TITLE
Loosen the find revision ID regex a bit to support more languages

### DIFF
--- a/src/differential/ArcanistDifferentialCommitMessage.php
+++ b/src/differential/ArcanistDifferentialCommitMessage.php
@@ -101,7 +101,7 @@ final class ArcanistDifferentialCommitMessage extends Phobject {
    */
   private function parseRevisionIDFromRawCorpus($corpus) {
     $match = null;
-    if (!preg_match('/^Differential Revision:\s*(.+)/im', $corpus, $match)) {
+    if (!preg_match('/Differential\s*[^:]+:\s*(.+)/im', $corpus, $match)) {
       return null;
     }
 


### PR DESCRIPTION
If `arc`'s language was set to a language other than English, it will fail to get the correct revision ID from commit message. For example, the Chinese version of `arc` will append something like `Differential 修订: http://phabricator.x.com/D438` instead of `Differential Revision: http://phabricator.x.com/D438`.
This PR loosen the regex a little bit to make arc can work perfectly on more languages, if not all