### PR TITLE
Fix XUnitTestEngine not running unit tests.

### DIFF
--- a/src/unit/ArcanistUnitTestResult.php
+++ b/src/unit/ArcanistUnitTestResult.php
@@ -87,7 +87,7 @@ final class ArcanistUnitTestResult extends Phobject {
     if (!is_int($duration) && !is_float($duration)) {
       throw new Exception(
         pht(
-          'Parameter passed to setDuration() must be an integer or a float.'));
+          'Parameter passed to setDuration() must be an integer or a float. It is %s.', $duration));
     }
     $this->duration = $duration;
     return $this;

--- a/src/unit/engine/XUnitTestEngine.php
+++ b/src/unit/engine/XUnitTestEngine.php
@@ -328,7 +328,7 @@ class XUnitTestEngine extends ArcanistUnitTestEngine {
         unlink($xunit_temp);
       }
       $future = new ExecFuture(
-        '%C %s /xml %s',
+        '%C %s -xml %s',
         trim($this->runtimeEngine.' '.$this->testEngine),
         $test_assembly,
         $xunit_temp);
@@ -420,7 +420,7 @@ class XUnitTestEngine extends ArcanistUnitTestEngine {
     $tests = $xunit_dom->getElementsByTagName('test');
     foreach ($tests as $test) {
       $name = $test->getAttribute('name');
-      $time = $test->getAttribute('time');
+      $time = floatval($test->getAttribute('time'));
       $status = ArcanistUnitTestResult::RESULT_UNSOUND;
       switch ($test->getAttribute('result')) {
         case 'Pass':


### PR DESCRIPTION
This pull requests intends to fix a bug where XUnitTestEngine was not running unit tests. 

This was tested using xunit.runner.console V2.2.0 and V.2.0.0. This was tested on a Windows environment with both Git bash and Microsoft Powershell.