### PR TITLE
Add support for Go 1.10 (cached) output

### DIFF
--- a/src/unit/parser/ArcanistGoTestResultParser.php
+++ b/src/unit/parser/ArcanistGoTestResultParser.php
@@ -68,7 +68,7 @@ final class ArcanistGoTestResultParser extends ArcanistTestResultParser {
       if (strncmp($line, 'ok', 2) === 0) {
         $meta = array();
         preg_match(
-          '/^ok[\s\t]+(?P<test_name>\w.*)[\s\t]+(?P<time>.*)s.*/',
+          '/^ok[\s\t]+(?P<test_name>\w.*)[\s\t]+(?:(?P<time>.*)s| \(cached\)).*/',
           $line,
           $meta);
 
@@ -84,7 +84,10 @@ final class ArcanistGoTestResultParser extends ArcanistTestResultParser {
           $result = new ArcanistUnitTestResult();
           $result->setName($test_name);
           $result->setResult(ArcanistUnitTestResult::RESULT_PASS);
-          $result->setDuration((float)$meta['time']);
+
+          if (array_key_exists('time', $meta)) {
+            $result->setDuration((float)$meta['time']);
+          }
 
           $results[] = $result;
         } else {

--- a/src/unit/parser/__tests__/ArcanistGoTestResultParserTestCase.php
+++ b/src/unit/parser/__tests__/ArcanistGoTestResultParserTestCase.php
@@ -103,6 +103,27 @@ final class ArcanistGoTestResultParserTestCase extends PhutilTestCase {
     }
   }
 
+  public function testNonVerboseOutputV110() {
+    $stubbed_results = Filesystem::readFile(
+      dirname(__FILE__).'/testresults/go.nonverbose-go1.10');
+
+    $parsed_results = id(new ArcanistGoTestResultParser())
+      ->parseTestResults('package', $stubbed_results);
+
+    $this->assertEqual(2, count($parsed_results));
+    $this->assertEqual(
+      'Go::TestCase::package::subpackage1',
+      $parsed_results[0]->getName());
+    $this->assertEqual(
+      'Go::TestCase::package::subpackage2',
+      $parsed_results[1]->getName());
+    foreach ($parsed_results as $result) {
+      $this->assertEqual(
+        ArcanistUnitTestResult::RESULT_PASS,
+        $result->getResult());
+    }
+  }
+
   public function testSingleTestCaseSuccessfulGo14() {
     $stubbed_results = Filesystem::readFile(
       dirname(__FILE__).'/testresults/go.single-test-case-successful-go1.4');


### PR DESCRIPTION
cc @epriestley 

Our Go test integration was giving me errors since in Go 1.10 there might be a `(cached)` output where there used to always be a time such as `0.1s`.

I've just implemented the most shallow fix, so please let me know if there's a different approach you'd like to take, but this cleans up the errors for me.