### PR TITLE
use mb_strlen instead of strlen to account for multi-byte characters

### DIFF
--- a/src/lint/engine/ArcanistLintEngine.php
+++ b/src/lint/engine/ArcanistLintEngine.php
@@ -397,7 +397,7 @@ abstract class ArcanistLintEngine extends Phobject {
       $line_number = 0;
       $line_start = 0;
       foreach ($lines as $line) {
-        $len = strlen($line) + 1; // Account for "\n".
+        $len = mb_strlen($line) + 1; // Account for "\n".
         $line_to_first_char[] = $line_start;
         $line_start += $len;
         for ($ii = 0; $ii < $len; $ii++) {


### PR DESCRIPTION
With the following test file:

```
↓↓↓↓↓↓
abcdef
ghijkl
```

when running:
```php
list($line, $char) = $this->getEngine()->getLineAndCharFromOffset('test', 15);
echo("line=$line, char=$char");
```

we get the following output:

`line=0, char=15`

after this patch, the output is more as expected:

`line=2, char=1`
