### PR TITLE
Ignore 'instability' column in mercurial output

### DIFF
--- a/src/repository/parser/ArcanistMercurialParser.php
+++ b/src/repository/parser/ArcanistMercurialParser.php
@@ -175,6 +175,7 @@ final class ArcanistMercurialParser extends Phobject {
             $commit['bookmark'] = $value;
             break;
           case 'obsolete':
+          case 'instability':
             // This is an extra field added by the "evolve" extension even
             // if HGPLAIN=1 is set. See PHI502.
             break;


### PR DESCRIPTION
Appears in some versions of mercurial with the changeset evolution
extension installed.

(Found / reported here: https://bugzilla.mozilla.org/show_bug.cgi?id=1468446) 