### PR TITLE
Update installation instruction for golint

### DIFF
--- a/src/lint/linter/ArcanistGoLintLinter.php
+++ b/src/lint/linter/ArcanistGoLintLinter.php
@@ -29,7 +29,7 @@ final class ArcanistGoLintLinter extends ArcanistExternalLinter {
   public function getInstallInstructions() {
     return pht(
       'Install Golint using `%s`.',
-      'go get github.com/golang/lint/golint');
+      'go get golang.org/x/lint/golint');
   }
 
   public function shouldExpectCommandErrors() {


### PR DESCRIPTION
Installation instruction for `golint` has changed with https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3. With this commit: https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58 it is enforced. This pull request is to update install instructions.