### PR TITLE
pylint --version in 2.1.1 no longer ends every line with a , like so:

### DIFF
--- a/src/lint/linter/ArcanistPyLintLinter.php
+++ b/src/lint/linter/ArcanistPyLintLinter.php
@@ -38,7 +38,7 @@ final class ArcanistPyLintLinter extends ArcanistExternalLinter {
     list($stdout) = execx('%C --version', $this->getExecutableCommand());
 
     $matches = array();
-    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+),/';
+    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+),?/';
     if (preg_match($regex, $stdout, $matches)) {
       return $matches['version'];
     } else {


### PR DESCRIPTION
When using `arc lint` with a newer version of `pylint` the version is not always detected correctly since `pylint --version` slightly changed the output format. This can lead to an error message like: 

```
 Exception 
ArcanistPyLintLinter is not compatible with the installed version of pylint. Minimum version: 1.0.0; installed version: .
(Run with `--trace` for a full exception trace.)

```

$ pylint --version
pylint 2.1.1

This regex works in both cases: with and without commata.