### PR TITLE
Remove trailing comma from pylint version match

### DIFF
--- a/src/lint/linter/ArcanistPyLintLinter.php
+++ b/src/lint/linter/ArcanistPyLintLinter.php
@@ -38,7 +38,7 @@ final class ArcanistPyLintLinter extends ArcanistExternalLinter {
     list($stdout) = execx('%C --version', $this->getExecutableCommand());
 
     $matches = array();
-    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+),/';
+    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+)/';
     if (preg_match($regex, $stdout, $matches)) {
       return $matches['version'];
     } else {


### PR DESCRIPTION
This trailing comma was removed in pylint version 2.x.x which caused `pylint --version` output to be parsed incorrectly.