### PR TITLE
Adjust pylint version regex to work with pylint 2.x

### DIFF
--- a/src/lint/linter/ArcanistPyLintLinter.php
+++ b/src/lint/linter/ArcanistPyLintLinter.php
@@ -38,7 +38,7 @@ final class ArcanistPyLintLinter extends ArcanistExternalLinter {
     list($stdout) = execx('%C --version', $this->getExecutableCommand());
 
     $matches = array();
-    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+),/';
+    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+),?/';
     if (preg_match($regex, $stdout, $matches)) {
       return $matches['version'];
     } else {


### PR DESCRIPTION
`pylint` 2.x doesn't print a `,` at the end of its version output; this small change just makes the `,` optional, so `arc lint` will work with the current version or legacy versions.