### PR TITLE
Allow the use of newer puppet-lint packages.

### DIFF
--- a/src/lint/linter/ArcanistPuppetLintLinter.php
+++ b/src/lint/linter/ArcanistPuppetLintLinter.php
@@ -53,6 +53,22 @@ final class ArcanistPuppetLintLinter extends ArcanistExternalLinter {
   }
 
   protected function getMandatoryFlags() {
+    $installed_version = $this->getVersion();
+    $last_linenumber_version = '2.0.2';
+
+    if (version_compare($installed_version, $last_linenumber_version, '>')) {
+      return array(
+        '--error-level=all',
+        sprintf('--log-format=%s', implode('|', array(
+          '%{line}',
+          '%{column}',
+          '%{kind}',
+          '%{check}',
+          '%{message}',
+        ))),
+      );
+    }
+
     return array(
       '--error-level=all',
       sprintf('--log-format=%s', implode('|', array(


### PR DESCRIPTION
puppet-lint deprecated the `linenumber` variable in version 1.0.0 (2014-08-18) and as of 2.1.0 (2016-12-30) it was completely removed. The last version of puppet-lint to support `linenumber` was 2.0.2 so set any newever versions to use the `line` variable instead.

Reference: https://github.com/rodjek/puppet-lint/blob/master/CHANGELOG.md