### PR TITLE
Modified msort to msortv

### DIFF
--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -1465,7 +1465,7 @@ EOTEXT
 
     $console->writeOut($message."\n\n");
 
-    $builds = msort($builds, 'getStatusSortVector');
+    $builds = msortv($builds, 'getStatusSortVector');
     foreach ($builds as $build) {
       $ansi_color = $build->getStatusANSIColor();
       $status_name = $build->getStatusName();


### PR DESCRIPTION
This fixed a problem I had - I don't know if this fix is desirable in general, but it solved my problem in this case.

Following from an error message from Harbormaster that said:

Harbormaster failed to build the active diff for this revision.

Exception 
msort() was passed a method ("getStatusSortVector") which returns "PhutilSortVector" objects. Use "msortv()", not "msort()", to sort a list which produces vectors.
(Run with `--trace` for a full exception trace.)