### PR TITLE
Adding a powershell script for windows users which aren't using cmd.exe

### DIFF
--- a/bin/arc.ps1
+++ b/bin/arc.ps1
@@ -1,0 +1,1 @@
+php -f $PSScriptRoot\..\scripts\arcanist.php -- $args


### PR DESCRIPTION
I realize this wouldn't perhaps be accepted, but it's functionally equivalent to the batch script and is a nicer alternative for powershell users on Windows.

The big reason I started using it is that when calling the batch script from powershell, a new cmd.exe window is opened and closed before I can read any output.