### PR TITLE
Update Go linter install link

### DIFF
--- a/src/lint/linter/ArcanistGoLintLinter.php
+++ b/src/lint/linter/ArcanistGoLintLinter.php
@@ -29,7 +29,7 @@ final class ArcanistGoLintLinter extends ArcanistExternalLinter {
   public function getInstallInstructions() {
     return pht(
       'Install Golint using `%s`.',
-      'go get github.com/golang/lint/golint');
+      'go get golang.org/x/lint/golint');
   }
 
   public function shouldExpectCommandErrors() {


### PR DESCRIPTION
Go updated the path for the linter, broke the old path for linter. [This issue](https://github.com/golang/lint/issues/415) confirms the change.