### PR TITLE
Make pylint binary pattern more general.

### DIFF
--- a/src/lint/linter/ArcanistPyLintLinter.php
+++ b/src/lint/linter/ArcanistPyLintLinter.php
@@ -38,7 +38,7 @@ final class ArcanistPyLintLinter extends ArcanistExternalLinter {
     list($stdout) = execx('%C --version', $this->getExecutableCommand());
 
     $matches = array();
-    $regex = '/^pylint (?P<version>\d+\.\d+\.\d+)/';
+    $regex = '/^pylint(3)? (?P<version>\d+\.\d+\.\d+)/';
     if (preg_match($regex, $stdout, $matches)) {
       return $matches['version'];
     } else {


### PR DESCRIPTION
Under Ubuntu, Python 3 version of pylint is installed through package
`python3-pylint`, and the executable is `pylint3`, the output of
`pylint3 --version` would be:

```
No config file found, using default configuration
pylint3 1.8.3,
astroid 1.6.0
Python 3.6.8 (default, Jan 14 2019, 11:02:34)
```

The current pattern fails to parse the output, this change addresses the
issue.