### PR TITLE
unbreak Puppet linter: use line format string instead of linenumber

### DIFF
--- a/src/lint/linter/ArcanistPuppetLintLinter.php
+++ b/src/lint/linter/ArcanistPuppetLintLinter.php
@@ -56,7 +56,7 @@ final class ArcanistPuppetLintLinter extends ArcanistExternalLinter {
     return array(
       '--error-level=all',
       sprintf('--log-format=%s', implode('|', array(
-        '%{linenumber}',
+        '%{line}',
         '%{column}',
         '%{kind}',
         '%{check}',


### PR DESCRIPTION
This diff updates ArcanistPuppetLintLinter.php to be compatible with the latest `puppet-lint`.

Based on the change made by the `puppet-lint` maintainers in Issue https://github.com/rodjek/puppet-lint/issues/539 and commithttps://github.com/rodjek/puppet-lint/pull/540 the `linenumber` format string is no longer supported.

While the issue was already reported in https://secure.phabricator.com/T10038 and https://secure.phabricator.com/T12169 it has never been fixed.