### PR TITLE
Throw exception on abandoned setting

### DIFF
--- a/src/configuration/ArcanistConfiguration.php
+++ b/src/configuration/ArcanistConfiguration.php
@@ -2,20 +2,7 @@
 
 /**
  * Runtime workflow configuration. In Arcanist, commands you type like
- * "arc diff" or "arc lint" are called "workflows". This class allows you to add
- * new workflows (and extend existing workflows) by subclassing it and then
- * pointing to your subclass in your project configuration.
- *
- * When specified as the **arcanist_configuration** class in your project's
- * `.arcconfig`, your subclass will be instantiated (instead of this class)
- * and be able to handle all the method calls. In particular, you can:
- *
- *    - create, replace, or disable workflows by overriding `buildWorkflow()`
- *      and `buildAllWorkflows()`;
- *    - add additional steps before or after workflows run by overriding
- *      `willRunWorkflow()` or `didRunWorkflow()` or `didAbortWorkflow()`; and
- *    - add new flags to existing workflows by overriding
- *      `getCustomArgumentsForCommand()`.
+ * "arc diff" or "arc lint" are called "workflows".
  *
  * @concrete-extensible
  */

--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -138,12 +138,21 @@ final class ArcanistSettings extends Phobject {
       ),
     );
 
+    // To give warning for abandoned settings, in case workflow broken without exceptions after upgrade.
+    $abandoned = array(
+      'arcanist_configuration' => array(
+        'type' => 'abandoned',
+        'help' => pht(
+          'Abandoned. Override ArcanistConfiguration.'),
+      ),
+    );
+
     $settings = ArcanistSetting::getAllSettings();
     foreach ($settings as $key => $setting) {
       $settings[$key] = $setting->getLegacyDictionary();
     }
 
-    $results = $settings + $legacy_builtins;
+    $results = $settings + $legacy_builtins + $abandoned;
     ksort($results);
 
     return $results;
@@ -245,6 +254,12 @@ final class ArcanistSettings extends Phobject {
           pht(
             'Use "arc alias" to configure aliases, not "arc set-config".'));
         break;
+      case 'abandoned':
+        throw new Exception(
+          pht(
+            "The setting '%s' has been abandoned. You should consider alternatives.",
+             $key));
+        break;
 
     }
 
@@ -279,7 +294,14 @@ final class ArcanistSettings extends Phobject {
         }
         break;
       case 'wild':
+        break;
       case 'aliases':
+        break;
+      case 'abandoned':
+        throw new Exception(
+          pht(
+            "The setting '%s' has been abandoned. You should consider alternatives.",
+              $key));
         break;
     }
 


### PR DESCRIPTION
Relative Question: [arcanist-configuration-not-respected](https://discourse.phabricator-community.org/t/arcanist-configuration-not-respected/3982)

After the [week 16 upgrade](https://secure.phabricator.com/T13488), setting "arcanist-configuration" has been abandoned however instructions still left in source code. Throw exceptions on that may helps prevent unwitting workflow broken.