### PR TITLE
Use XDG config dir by default on Unix platforms

### DIFF
--- a/src/config/ArcanistConfigurationEngine.php
+++ b/src/config/ArcanistConfigurationEngine.php
@@ -92,7 +92,17 @@ final class ArcanistConfigurationEngine
     if (phutil_is_windows()) {
       return getenv('APPDATA').'/.arcrc';
     } else {
-      return getenv('HOME').'/.arcrc';
+      $home_dir = getenv('HOME');
+      $old_config = $home_dir.'/.arcrc';
+      $xdg_config_dir = getenv('XDG_CONFIG_DIR');
+
+      if (file_exists($old_config)) {
+        return $old_config;
+      } elseif ($xdg_config_dir == FALSE) {
+        return $home_dir.'/.config/arcrc';
+      } else {
+        return $xdg_config_dir.'/.config/arcrc';
+      }
     }
   }
 

--- a/src/configuration/ArcanistConfigurationManager.php
+++ b/src/configuration/ArcanistConfigurationManager.php
@@ -194,10 +194,10 @@ final class ArcanistConfigurationManager extends Phobject {
             $prompt = pht(
               "File permissions on your %s are too open. ".
               "Fix them by chmod'ing to 600?",
-              '~/.arcrc');
+              $user_config_path);
             if (!phutil_console_confirm($prompt, $default_no = false)) {
               throw new ArcanistUsageException(
-                pht('Set %s to file mode 600.', '~/.arcrc'));
+                pht('Set %s to file mode 600.', $user_config_path));
             }
             execx('chmod 600 %s', $user_config_path);
 
@@ -213,7 +213,7 @@ final class ArcanistConfigurationManager extends Phobject {
           $user_config = phutil_json_decode($user_config_data);
         } catch (PhutilJSONParserException $ex) {
           throw new PhutilProxyException(
-            pht("Your '%s' file is not a valid JSON file.", '~/.arcrc'),
+            pht("Your '%s' file is not a valid JSON file.", $user_config_path),
             $ex);
         }
       } else {
@@ -265,7 +265,17 @@ final class ArcanistConfigurationManager extends Phobject {
     if (phutil_is_windows()) {
       return getenv('APPDATA').'/.arcrc';
     } else {
-      return getenv('HOME').'/.arcrc';
+      $home_dir = getenv('HOME');
+      $old_config = $home_dir.'/.arcrc';
+      $xdg_config_dir = getenv('XDG_CONFIG_DIR');
+
+      if (file_exists($old_config)) {
+        return $old_config;
+      } elseif ($xdg_config_dir == FALSE) {
+        return $home_dir.'/.config/arcrc';
+      } else {
+        return $xdg_config_dir.'/.config/arcrc';
+      }
     }
   }
 

--- a/src/future/http/HTTPSFuture.php
+++ b/src/future/http/HTTPSFuture.php
@@ -34,7 +34,7 @@ final class HTTPSFuture extends BaseHTTPFuture {
    *
    * This allows us to do host-specific SSL certificates in whatever client
    * is using libphutil. e.g. in Arcanist, you could add an "ssl_cert" key
-   * to a specific host in ~/.arcrc and use that.
+   * to a specific host in the config file and use that.
    *
    * cURL needs this to be a file, it doesn't seem to be able to handle a string
    * which contains the cert. So we make a temporary file and store it there.

--- a/src/workflow/ArcanistInstallCertificateWorkflow.php
+++ b/src/workflow/ArcanistInstallCertificateWorkflow.php
@@ -19,7 +19,7 @@ EOTEXT
   public function getCommandHelp() {
     return phutil_console_format(<<<EOTEXT
           Supports: http, https
-          Installs Conduit credentials into your ~/.arcrc for the given install
+          Installs Conduit credentials into your config file for the given install
           of Phabricator. You need to do this before you can use 'arc', as it
           enables 'arc' to link your command-line activity with your account on
           the web. Run this command from within a project directory to install
@@ -55,6 +55,7 @@ EOTEXT
     $configuration_manager = $this->getConfigurationManager();
 
     $config = $configuration_manager->readUserConfigurationFile();
+    $config_path = $configuration_manager->getUserConfigurationFileLocation();
 
     $this->writeInfo(
       pht('CONNECT'),
@@ -168,7 +169,7 @@ EOTEXT
       );
     }
 
-    echo pht('Writing %s...', '~/.arcrc')."\n";
+    echo pht('Writing %s...', $config_path)."\n";
     $configuration_manager->writeUserConfigurationFile($config);
 
     if ($is_token_auth) {

--- a/src/workflow/ArcanistSetConfigWorkflow.php
+++ b/src/workflow/ArcanistSetConfigWorkflow.php
@@ -26,9 +26,10 @@ EOTEXT
           copy). By default, user configuration is written. Use __--local__
           to write local configuration.
 
-          User values are written to '~/.arcrc' on Linux and Mac OS X, and an
-          undisclosed location on Windows. Local values are written to an arc
-          directory under either .git, .hg, or .svn as appropriate.
+          User values are written to '~/.config/arcrc' on Linux and Mac OS X by 
+          default, or '~/.arcrc' on old installations, and an undisclosed 
+          location on Windows. Local values are written to an arc directory 
+          under either .git, .hg, or .svn as appropriate.
 EOTEXT
       );
   }

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -397,12 +397,12 @@ abstract class ArcanistWorkflow extends Phobject {
    * credentials can then be used to establish an authenticated connection to
    * conduit by calling @{method:authenticateConduit}. Arcanist sets some
    * defaults for all workflows regardless of whether or not they return true
-   * from @{method:requireAuthentication}, based on the ##~/.arcrc## and
-   * ##.arcconf## files if they are present. Thus, you can generally upgrade a
-   * workflow which does not require authentication into an authenticated
-   * workflow by later invoking @{method:requireAuthentication}. You should not
-   * normally need to call this method unless you are specifically overriding
-   * the defaults.
+   * from @{method:requireAuthentication}, based on the ##~/.config/arcrc## (or
+   * ##~/.arcrc##) and ##.arcconf## files if they are present. Thus, you can
+   * generally upgrade a workflow which does not require authentication into 
+   * an authenticated workflow by later invoking @{method:requireAuthentication}.
+   * You should not normally need to call this method unless you are specifically
+   * overriding the defaults.
    *
    * NOTE: You can not call this method after calling
    * @{method:authenticateConduit}.


### PR DESCRIPTION
This PR makes the following change to arcanist's config file detection on Unix platforms:
- If `~/.arcrc` already exists, use it
- Otherwise, if `XDG_CONFIG_HOME` is set, use a configuration file at `$XDG_CONFIG_HOME/arcrc`
- Otherwise, if `XDG_CONFIG_HOME` is unset, use a configuration file at `$HOME/.config/arcrc`

This behavior is compliant with the XDG Base Directory Specification and is backwards-compatible with existing installations.