### PR TITLE
Handle `ERR-INVALID-AUTH` responses from Conduit in `patch` workflow

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -391,7 +391,8 @@ EOTEXT
           break;
       }
     } catch (ConduitClientException $ex) {
-      if ($ex->getErrorCode() == 'ERR-INVALID-SESSION') {
+      if ($ex->getErrorCode() == 'ERR-INVALID-SESSION' ||
+           $ex->getErrorCode() == 'ERR-INVALID-AUTH') {
         // Phabricator is not configured to allow anonymous access to
         // Differential.
         $this->authenticateConduit();


### PR DESCRIPTION
Conduit responds to requests with either `ERR-INVALID-SESSION` or `ERR-INVALID-AUTH` if the request wasn't sufficiently authenticated. Arcanist's `patch` workflow can automatically attempt to recover from situations in which Conduit responds to unauthenticated requests with `ERR-INVALID-SESSION` (by resending an authenticated version of the request), but not `ERR-INVALID-AUTH` - recover from `ERR-INVALID-AUTH` in the same way.