### PR TITLE
Open an issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Arcanist is the command-line tool for [Phabricator](http://phabricator.org).
 It allows you to interact with Phabricator installs to send code for review,
 download patches, transfer files, view status, make API calls, and various other
-things. You can read more in the [User Guide](https://secure.phabricator.com/book/phabricator/article/arcanist/)
+things. You can read more in the [User Guide](https://secure.phabricator.com/book/phabricator/article/arcanist/).
 
 For more information about Phabricator, see http://phabricator.org/.
 


### PR DESCRIPTION
LLVM project use arcnist to upload the patch. But they need to cherry-pick a commit https://llvm.org/docs/GettingStarted.html#sending-patches , https://github.com/rashkov/arcanist/commit/e3659d43d8911e91739f3b0c5935598bceb859aa. It is possible to fix this in upstream arcanist?