### PR TITLE
More PHP 8.1 behavior corrections

### DIFF
--- a/src/lint/renderer/ArcanistConsoleLintRenderer.php
+++ b/src/lint/renderer/ArcanistConsoleLintRenderer.php
@@ -119,7 +119,7 @@ final class ArcanistConsoleLintRenderer extends ArcanistLintRenderer {
 
     $old = $data;
     $old_lines = phutil_split_lines($old);
-    $old_impact = substr_count($original, "\n") + 1;
+    $old_impact = substr_count(isset($original) ? $original : "", "\n") + 1;
     $start = $line;
 
     // See PHI1782. If a linter raises a message at a line that does not
@@ -242,7 +242,7 @@ final class ArcanistConsoleLintRenderer extends ArcanistLintRenderer {
       // If we have "original" text and it is contained on a single line,
       // highlight the affected area. If we don't have any text, we'll mark
       // the character with a caret (below, in rendering) instead.
-      if ($old_impact == 1 && strlen($original)) {
+      if ($old_impact == 1 && ($original !== null && strlen($original))) {
         $old_lines[$start - 1] = substr_replace(
           $old_lines[$start - 1],
           $this->highlightText($original),
@@ -324,7 +324,7 @@ final class ArcanistConsoleLintRenderer extends ArcanistLintRenderer {
       // If this is just a message and does not have a patch, put a little
       // caret underneath the line to point out where the issue is.
       if ($chevron) {
-        if (!$message->isPatchable() && !strlen($original)) {
+        if (!$message->isPatchable() && $original === null) {
           $result[] = $this->renderCaret($char)."\n";
         }
       }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2360,7 +2360,7 @@ EOTEXT
 
     // If we track an upstream branch either directly or indirectly, use that.
     $branch = $api->getBranchName();
-    if (strlen($branch)) {
+    if ($branch !== null && strlen($branch)) {
       $upstream_path = $api->getPathToUpstream($branch);
       $remote_branch = $upstream_path->getRemoteBranchName();
       if ($remote_branch !== null) {


### PR DESCRIPTION
These were needed to complete `arc diff` and `arc land` runs on my machine with PHP 8.1.4.

Also tested for backwards compatibility with PHP 8.0.17.