### PR TITLE
Treat variable that might be null for PHP 8

### DIFF
--- a/src/parser/ArcanistBundle.php
+++ b/src/parser/ArcanistBundle.php
@@ -762,7 +762,11 @@ final class ArcanistBundle extends Phobject {
       $old_data = $this->getBlob($old_phid, $name);
     }
 
-    $old_length = strlen($old_data);
+    if (phutil_nonempty_string($old_data)) {
+      $old_length = strlen($old_data);
+    } else {
+      $old_length = 0;
+    }
 
     // Here, and below, the binary will be emitted with base85 encoding. This
     // encoding encodes each 4 bytes of input in 5 bytes of output, so we may

--- a/src/unit/renderer/ArcanistUnitConsoleRenderer.php
+++ b/src/unit/renderer/ArcanistUnitConsoleRenderer.php
@@ -12,7 +12,7 @@ final class ArcanistUnitConsoleRenderer extends ArcanistUnitRenderer {
 
     $test_name = $result->getName();
     $test_namespace = $result->getNamespace();
-    if (strlen($test_namespace)) {
+    if (phutil_nonempty_string($test_namespace) && strlen($test_namespace)) {
       $test_name = $test_namespace.'::'.$test_name;
     }
 


### PR DESCRIPTION
It follows the recommended solution in https://secure.phabricator.com/T13588#256584. The treated variables might be null when running `arc patch <diff_number>` or `arc unit` with a `PytestTestEngine` unit test. The caused errors are similar, for example:

```
[2022-05-03 06:44:43] EXCEPTION: (RuntimeException) strlen(): Passing null to parameter #1 ($string) of type string is deprecated at [<arcanist>/src/error/PhutilErrorHandler.php:263]
arcanist(), arcanist-plugins(head=master, ref.master=765dbba3ec08), shellcheck-linter(head=add_disable_option, ref.master=01f6d6d0f05a, ref.add_disable_option=f054dd36c7e4)
  #0 PhutilErrorHandler::handleError(integer, string, string, integer) called at [<arcanist>/src/parser/ArcanistBundle.php:765]
  #1 ArcanistBundle::buildBinaryChange(ArcanistDiffChange, NULL) called at [<arcanist>/src/parser/ArcanistBundle.php:409]
  #2 ArcanistBundle::toGitPatch() called at [<arcanist>/src/workflow/ArcanistPatchWorkflow.php:704]
  #3 ArcanistPatchWorkflow::run() called at [<arcanist>/src/workflow/ArcanistPatchWorkflow.php:398]
  #4 ArcanistPatchWorkflow::run() called at [<arcanist>/scripts/arcanist.php:427]
```