### PR TITLE
Avoid calling strlen(null) when there is no branch

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2361,7 +2361,7 @@ EOTEXT
 
     // If we track an upstream branch either directly or indirectly, use that.
     $branch = $api->getBranchName();
-    if (strlen($branch)) {
+    if (phutil_nonempty_string($branch)) {
       $upstream_path = $api->getPathToUpstream($branch);
       $remote_branch = $upstream_path->getRemoteBranchName();
       if ($remote_branch !== null) {


### PR DESCRIPTION
I see recent PHP 8.1 patches to upstream arcanist, but no way to submit fixes.

The https://secure.phabricator.com/book/phabcontrib/article/contributing_code/ link just reads, "Effective June 1, 2021: Phabricator is no longer actively maintained, and no longer accepting contributions."

https://secure.phabricator.com/login reads, "NOTE: You can not register a new account here. You must be invited to join the upstream."

Anyway, I don't care about being credited for a one-word patch, so feel free to make a Phabricator revision and disregard this pull request.

I hit this bug when I ran `git rebase` followed by `arc diff`:
```
$ arc --trace diff
...
[2022-06-08 01:57:09] EXCEPTION: (RuntimeException) strlen(): Passing null to parameter #1 ($string) of type string is deprecated at [<arcanist>/src/error/PhutilErrorHandler.php:261]
arcanist(head=master, ref.master=85c953ebe4a6)
  #0 PhutilErrorHandler::handleError(integer, string, string, integer) called at [<arcanist>/src/workflow/ArcanistDiffWorkflow.php:2364]
  #1 ArcanistDiffWorkflow::getDiffOntoTargets() called at [<arcanist>/src/workflow/ArcanistDiffWorkflow.php:2342]
  #2 ArcanistDiffWorkflow::updateOntoDiffProperty() called at [<arcanist>/src/workflow/ArcanistDiffWorkflow.php:409]
  #3 ArcanistDiffWorkflow::run() called at [<arcanist>/scripts/arcanist.php:427]
```


