### PR TITLE
Allow https.cabundle to be a directory.

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -35,7 +35,7 @@ final class ArcanistArcConfigurationEngineExtension
       'https.cabundle' => array(
         'type' => 'string',
         'help' => pht(
-          "Path to a custom CA bundle file to be used for arcanist's cURL ".
+          "Path to certificate bundle or directory to be used for cURL calls. ".
           "calls. This is used primarily when your conduit endpoint is ".
           "behind HTTPS signed by your organization's internal CA."),
         'example' => 'support/yourca.pem',

--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -95,7 +95,7 @@ final class ArcanistSettings extends Phobject {
       'https.cabundle' => array(
         'type' => 'string',
         'help' => pht(
-          "Path to a custom CA bundle file to be used for cURL calls. ".
+          "Path to certificate bundle or directory to be used for cURL calls. ".
           "This is used primarily when your conduit endpoint is ".
           "behind HTTPS signed by your organization's internal CA."),
         'example' => 'support/yourca.pem',

--- a/src/future/http/HTTPSFuture.php
+++ b/src/future/http/HTTPSFuture.php
@@ -399,7 +399,12 @@ final class HTTPSFuture extends BaseHTTPFuture {
       }
 
       if ($this->canSetCAInfo()) {
-        curl_setopt($curl, CURLOPT_CAINFO, $this->getCABundle());
+        $path = $this->getCABundle();
+        if (is_dir($path)) {
+          curl_setopt($curl, CURLOPT_CAPATH, $path);
+        } else {
+          curl_setopt($curl, CURLOPT_CAINFO, $path);
+        }
       }
 
       $verify_peer = 1;


### PR DESCRIPTION
Arcanist really, really wants to set a CA bundle.  This is wrong.  It should rely on Curl to pick up the system trust store and only try to force its own if the user explicitly requested it.  But for now, allowing https.cabundle to refer to a directory (which will be passed to CURL_CAPATH instead of CURL_CAINFO) will make life easier for integrators on platforms where the system trust store is a directory.