### PR TITLE
filesystem: Silence a deprecation warning

### DIFF
--- a/src/filesystem/Filesystem.php
+++ b/src/filesystem/Filesystem.php
@@ -931,7 +931,7 @@ final class Filesystem extends Phobject {
     if (phutil_is_windows()) {
       return (bool)preg_match('/^[A-Za-z]+:/', $path);
     } else {
-      return !strncmp($path, DIRECTORY_SEPARATOR, 1);
+      return !strncmp($path ?? '', DIRECTORY_SEPARATOR, 1);
     }
   }
 


### PR DESCRIPTION
Silence `Passing null to parameter #1 ($string1) of type string is deprecated` by using the null coalescing operator with an empty string as fallback.