### PR TITLE
Updates for PHP 8.4 compatibility

### DIFF
--- a/src/future/FutureProxy.php
+++ b/src/future/FutureProxy.php
@@ -8,7 +8,7 @@ abstract class FutureProxy extends Future {
 
   private $proxied;
 
-  public function __construct(Future $proxied = null) {
+  public function __construct(?Future $proxied = null) {
     if ($proxied) {
       $this->setProxiedFuture($proxied);
     }

--- a/src/parser/aast/api/AASTNode.php
+++ b/src/parser/aast/api/AASTNode.php
@@ -42,7 +42,7 @@ abstract class AASTNode extends Phobject {
     return $this->parentNode;
   }
 
-  final public function setParentNode(AASTNode $node = null) {
+  final public function setParentNode(?AASTNode $node = null) {
     $this->parentNode = $node;
     return $this;
   }
@@ -51,7 +51,7 @@ abstract class AASTNode extends Phobject {
     return $this->previousSibling;
   }
 
-  final public function setPreviousSibling(AASTNode $node = null) {
+  final public function setPreviousSibling(?AASTNode $node = null) {
     $this->previousSibling = $node;
     return $this;
   }
@@ -60,7 +60,7 @@ abstract class AASTNode extends Phobject {
     return $this->nextSibling;
   }
 
-  final public function setNextSibling(AASTNode $node = null) {
+  final public function setNextSibling(?AASTNode $node = null) {
     $this->nextSibling = $node;
     return $this;
   }

--- a/src/parser/argument/PhutilArgumentParser.php
+++ b/src/parser/argument/PhutilArgumentParser.php
@@ -490,7 +490,7 @@ final class PhutilArgumentParser extends Phobject {
     if ($workflow->isExecutable()) {
       $workflow->setArgv($this);
       $err = $workflow->execute($this);
-      exit($err);
+      exit((int)$err);
     } else {
       return $workflow;
     }

--- a/src/repository/marker/ArcanistMarkerRef.php
+++ b/src/repository/marker/ArcanistMarkerRef.php
@@ -174,7 +174,7 @@ final class ArcanistMarkerRef
     return $this->getHardpoint(self::HARDPOINT_WORKINGCOPYSTATEREF);
   }
 
-  public function attachRemoteRef(ArcanistRemoteRef $ref = null) {
+  public function attachRemoteRef(?ArcanistRemoteRef $ref = null) {
     return $this->attachHardpoint(self::HARDPOINT_REMOTEREF, $ref);
   }
 

--- a/src/repository/marker/ArcanistMercurialRepositoryMarkerQuery.php
+++ b/src/repository/marker/ArcanistMercurialRepositoryMarkerQuery.php
@@ -7,11 +7,11 @@ final class ArcanistMercurialRepositoryMarkerQuery
     return $this->newMarkers();
   }
 
-  protected function newRemoteRefMarkers(ArcanistRemoteRef $remote = null) {
+  protected function newRemoteRefMarkers(?ArcanistRemoteRef $remote = null) {
     return $this->newMarkers($remote);
   }
 
-  private function newMarkers(ArcanistRemoteRef $remote = null) {
+  private function newMarkers(?ArcanistRemoteRef $remote = null) {
     $api = $this->getRepositoryAPI();
 
     // In native Mercurial it is difficult to identify remote markers, and

--- a/src/unit/ArcanistUnitTestResult.php
+++ b/src/unit/ArcanistUnitTestResult.php
@@ -111,7 +111,7 @@ final class ArcanistUnitTestResult extends Phobject {
    * "extra data" allows an implementation to store additional key/value
    * metadata along with the result of the test run.
    */
-  public function setExtraData(array $extra_data = null) {
+  public function setExtraData(?array $extra_data = null) {
     $this->extraData = $extra_data;
     return $this;
   }

--- a/src/unit/engine/ArcanistUnitTestEngine.php
+++ b/src/unit/engine/ArcanistUnitTestEngine.php
@@ -78,7 +78,7 @@ abstract class ArcanistUnitTestEngine extends Phobject {
     return $this->enableCoverage;
   }
 
-  final public function setRenderer(ArcanistUnitRenderer $renderer = null) {
+  final public function setRenderer(?ArcanistUnitRenderer $renderer = null) {
     $this->renderer = $renderer;
     return $this;
   }

--- a/support/init/init-arcanist.php
+++ b/support/init/init-arcanist.php
@@ -5,4 +5,4 @@ require_once dirname(__FILE__).'/init-script.php';
 $runtime = new ArcanistRuntime();
 $err = $runtime->execute($argv);
 
-exit($err);
+exit((int)$err);


### PR DESCRIPTION
- Fixed `FutureProxy::__construct(): Implicitly marking parameter $proxied as nullable is deprecated, the explicit nullable type must be used instead`.
- Fixed `Implicitly marking parameter $proxied as nullable is deprecated, the explicit nullable type must be used instead`.
- Fixed `Passing null to parameter #1 ($status) of type string|int is deprecated`.